### PR TITLE
Add env vars for Claude model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy to .env and fill in your actual Anthropic API key
+VITE_CLAUDE_API_KEY=
+CLAUDE_API_KEY=
+
+# Choose the Claude model to use (default uses the cheaper Haiku model)
+VITE_CLAUDE_MODEL=claude-3-haiku-20240307
+CLAUDE_MODEL=claude-3-haiku-20240307

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dist-ssr
 # Environment variables
 .env
 .env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -44,13 +44,18 @@ This is a React-based learning platform for Data Engineering concepts, including
 
 ### Environment Variables
 
-Create a `.env` file in the root directory with:
+Create a `.env` file in the root directory (see `.env.example` for a template) and provide your Anthropic API key:
 
 ```
 CLAUDE_API_KEY=your_api_key_here
+VITE_CLAUDE_API_KEY=your_api_key_here
+
+# Optional: choose which Claude model to use
+CLAUDE_MODEL=claude-3-haiku-20240307
+VITE_CLAUDE_MODEL=claude-3-haiku-20240307
 ```
 
-This key is read only on the server. Client code calls the `/api/claudeProxy` endpoint which forwards requests to Anthropics' API.
+The client loads `VITE_CLAUDE_API_KEY` and `VITE_CLAUDE_MODEL` at build time. All requests go through `/api/claudeProxy`, which uses `CLAUDE_API_KEY` and `CLAUDE_MODEL` on the server.
 
 ### Serverless Deployment
 

--- a/api/claudeProxy.ts
+++ b/api/claudeProxy.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 const CLAUDE_ENDPOINT = 'https://api.anthropic.com/v1/messages';
+const DEFAULT_MODEL = process.env.CLAUDE_MODEL || 'claude-3-haiku-20240307';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
@@ -16,7 +17,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   try {
-    const response = await axios.post(CLAUDE_ENDPOINT, req.body, {
+    const body = { ...req.body, model: req.body.model || DEFAULT_MODEL };
+    const response = await axios.post(CLAUDE_ENDPOINT, body, {
       headers: {
         'Content-Type': 'application/json',
         'x-api-key': apiKey,
@@ -41,9 +43,10 @@ export const handler = async (event: any) => {
   }
 
   const body = event.body ? JSON.parse(event.body) : {};
+  const requestBody = { ...body, model: body.model || DEFAULT_MODEL };
 
   try {
-    const response = await axios.post(CLAUDE_ENDPOINT, body, {
+    const response = await axios.post(CLAUDE_ENDPOINT, requestBody, {
       headers: {
         'Content-Type': 'application/json',
         'x-api-key': apiKey,

--- a/src/services/claudeApi.ts
+++ b/src/services/claudeApi.ts
@@ -102,9 +102,11 @@ export const generateFeedback = async (
 
   try {
     console.log('Calling Claude API...');
-    
+
+    const model = import.meta.env.VITE_CLAUDE_MODEL || 'claude-3-haiku-20240307';
+
     const payload = {
-      model: 'claude-3-5-sonnet-20241022', // Use the latest available model
+      model,
       messages: [
         {
           role: 'user',


### PR DESCRIPTION
## Summary
- support specifying Claude model via environment variables
- add `.env.example` template for API key and model
- document new configuration in README

## Testing
- `npm run lint` *(fails: unexpected any and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_6851cc4b46348333adad1f0595f70a31