### PR TITLE
Support runtime API key for practice chat

### DIFF
--- a/api/claudeProxy.ts
+++ b/api/claudeProxy.ts
@@ -10,7 +10,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return;
   }
 
-  const apiKey = process.env.CLAUDE_API_KEY;
+  // Allow API key to be supplied in the request header for local/static deployments
+  const apiKey =
+    (req.headers['x-api-key'] as string | undefined) || process.env.CLAUDE_API_KEY;
   if (!apiKey) {
     res.status(500).json({ error: 'CLAUDE_API_KEY is not set' });
     return;
@@ -37,7 +39,8 @@ export const handler = async (event: any) => {
     return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) };
   }
 
-  const apiKey = process.env.CLAUDE_API_KEY;
+  const apiKey =
+    (event.headers?.['x-api-key'] as string | undefined) || process.env.CLAUDE_API_KEY;
   if (!apiKey) {
     return { statusCode: 500, body: JSON.stringify({ error: 'CLAUDE_API_KEY is not set' }) };
   }

--- a/src/services/claudeApi.ts
+++ b/src/services/claudeApi.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { getApiKey } from '../utils/helpers';
 
 // Requests are now proxied through the serverless function
 const CLAUDE_API_URL = '/api/claudeProxy';
@@ -141,12 +142,14 @@ Keep feedback practical and interview-focused (not academic).`
       contentType: 'application/json'
     });
 
+    const apiKey = getApiKey();
     const response = await axios.post(
       CLAUDE_API_URL,
       payload,
       {
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          ...(apiKey ? { 'x-api-key': apiKey } : {})
         },
         timeout: 30000
       }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -104,3 +104,12 @@ export const getFromLocalStorage = <T,>(key: string, defaultValue: T): T => {
     return defaultValue;
   }
 };
+
+// Retrieve the Claude API key from env or localStorage
+export const getApiKey = (): string | undefined => {
+  const raw = import.meta.env.VITE_CLAUDE_API_KEY as string | undefined;
+  const cleaned = typeof raw === 'string' ? raw.replace(/^['"]|['"]$/g, '').trim() : undefined;
+  if (cleaned) return cleaned;
+  const stored = localStorage.getItem('claude_api_key');
+  return stored || undefined;
+};


### PR DESCRIPTION
## Summary
- allow Claude API key to be provided via `x-api-key` header in `claudeProxy` serverless function
- send API key from browser when available
- add helper to load key from environment or `localStorage`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: TypeScript errors and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6851d0c4170c8333b6f5b2a4cea681b7